### PR TITLE
test: verify Codecov PR flow

### DIFF
--- a/src/git/git-service.ts
+++ b/src/git/git-service.ts
@@ -368,6 +368,7 @@ export class GitService {
 
   private async getRemoteNames(): Promise<string[]> {
     const now = Date.now();
+    // 30s TTL: remote names rarely change at runtime; addRemote/removeRemote invalidate explicitly.
     if (this.cachedRemoteNames && now - this.remoteNamesCacheTime < 30000) {
       return this.cachedRemoteNames;
     }

--- a/src/git/git-service.ts
+++ b/src/git/git-service.ts
@@ -17,6 +17,8 @@ export class GitError extends Error {
   }
 }
 
+const REMOTE_NAMES_CACHE_TTL_MS = 30_000;
+
 export class GitService {
   private activityLog: Array<{ command: string; timestamp: string; success: boolean; duration: number }> = [];
   private cachedRemoteNames: string[] | null = null;
@@ -368,8 +370,8 @@ export class GitService {
 
   private async getRemoteNames(): Promise<string[]> {
     const now = Date.now();
-    // 30s TTL: remote names rarely change at runtime; addRemote/removeRemote invalidate explicitly.
-    if (this.cachedRemoteNames && now - this.remoteNamesCacheTime < 30000) {
+    // Remote names rarely change at runtime; addRemote/removeRemote invalidate explicitly.
+    if (this.cachedRemoteNames && now - this.remoteNamesCacheTime < REMOTE_NAMES_CACHE_TTL_MS) {
       return this.cachedRemoteNames;
     }
     // Dedupe concurrent callers: if a request is already in flight, await it


### PR DESCRIPTION
## Summary
- Verify the PR → CI → Codecov auto-comment pipeline works end-to-end by adding a single-line comment.
- Change: clarifies the rationale behind the 30s TTL in `getRemoteNames`.

## Expected
- CI (Node 20, 22) passes.
- Codecov posts an automated comment (informational only — should never fail the check).
- Patch coverage: the changed line is a comment, so it likely won't count toward patch coverage; expect a diff-style comment only.

## Test plan
- [ ] All CI steps pass.
- [ ] Codecov comment appears on the PR.
- [ ] Project and patch coverage numbers shown in the comment look sane.