### PR TITLE
Fix GIT_SEQUENCE_EDITOR for Windows cmd syntax

### DIFF
--- a/src/git/git-service.ts
+++ b/src/git/git-service.ts
@@ -1228,9 +1228,7 @@ export class GitService {
             GIT_EDITOR: 'true',
             EDITOR: 'true',
             GHG_TODO_FILE: todoFile,
-            GIT_SEQUENCE_EDITOR: process.platform === 'win32'
-              ? `copy /Y "%GHG_TODO_FILE%"`
-              : `cp -- "$GHG_TODO_FILE"`,
+            GIT_SEQUENCE_EDITOR: `cp -- "$GHG_TODO_FILE"`,
           },
         });
 


### PR DESCRIPTION
Fix the failure caused by using cmd syntax for the interactive variable GIT_SEQUENCE_EDITOR on Windows
Issue #25 