### PR TITLE
style: unify monospace font-family

### DIFF
--- a/webview-ui/src/components/common/BisectBanner.svelte
+++ b/webview-ui/src/components/common/BisectBanner.svelte
@@ -181,7 +181,7 @@
   }
 
   .bisect-hash {
-    font-family: monospace;
+    font-family: var(--vscode-editor-font-family, monospace);
     font-weight: 600;
     color: var(--text-primary);
   }

--- a/webview-ui/src/components/common/Modal.svelte
+++ b/webview-ui/src/components/common/Modal.svelte
@@ -402,7 +402,7 @@
   }
 
   :global(.modal-hash) {
-    font-family: monospace;
+    font-family: var(--vscode-editor-font-family, monospace);
     color: var(--text-secondary);
   }
 

--- a/webview-ui/src/components/graph/CommitGraph.svelte
+++ b/webview-ui/src/components/graph/CommitGraph.svelte
@@ -1992,7 +1992,7 @@
   }
 
   .bisect-indicator-hash {
-    font-family: monospace;
+    font-family: var(--vscode-editor-font-family, monospace);
     color: #f44336;
   }
 


### PR DESCRIPTION
# Pull Request

## 1. Summary

Replaces the few ocurrences of
```css
font-family: monospace;
```
that are not using the variable `--vscode-editor-font-family` with
```css
font-family: var(--vscode-editor-font-family, monospace);
```
, as seen many other places in the CSS

## 2. Related Issue

N/A

## 3. Changes

### Webview (`webview-ui/`)

- webview-ui/src/components/common/BisectBanner.svelte
- webview-ui/src/components/common/Modal.svelte
- webview-ui/src/components/graph/CommitGraph.svelte

## 4. Type of Change

Check all that apply.

- [ ] New feature
- [ ] Bug fix
- [X] Refactoring (no functional changes)
- [ ] Style / UI update
- [ ] i18n (localization) addition or update
- [ ] Build / configuration change
- [ ] Documentation update
- [ ] Test addition or update

## 5. Testing

Describe how you verified the changes.

- [ ] `npm test` passed
- [ ] `npm run lint` passed
- [X] Manually tested via VS Code Extension Host
- [ ] Verified in both dark and light themes (if UI was changed)

## 6. Screenshots (optional)

N/A

## 7. Checklist

- [ ] New message types are defined in `message-bus.ts` (if applicable)
- [ ] UI strings are added to both `en.ts` and `ko.ts` (if applicable)
- [ ] Extension-side strings are added to both `l10n/bundle.l10n.json` and `bundle.l10n.ko.json` (if applicable)
- [ ] No leftover `console.log` or debug code
