### PR TITLE
style: unify font-family in commit graph header and reflog header

### DIFF
--- a/webview-ui/src/components/common/Reflog.svelte
+++ b/webview-ui/src/components/common/Reflog.svelte
@@ -781,9 +781,9 @@
   }
 
   /* ── 행 ─────────────────────────────────────────────── */
-  .reflog-list { 
-    flex: 1; 
-    overflow-y: auto; 
+  .reflog-list {
+    flex: 1;
+    overflow-y: auto;
     overflow-x: hidden;
     position: relative;
   }
@@ -874,6 +874,10 @@
     padding: 0 10px;
     font-family: var(--vscode-editor-font-family, monospace);
     color: var(--text-secondary);
+  }
+
+  .reflog-header .col-hash {
+    font-family: inherit;
   }
 
   .col-date {

--- a/webview-ui/src/components/graph/CommitGraph.svelte
+++ b/webview-ui/src/components/graph/CommitGraph.svelte
@@ -1787,6 +1787,10 @@
     white-space: nowrap;
   }
 
+  .graph-header .col-hash {
+    font-family: inherit;
+  }
+
   .commit-subject {
     flex: 1;
     min-width: 0;


### PR DESCRIPTION
# Pull Request

## 1. Summary

The hash column uses monospace font, but that monospace font is also used in the header.
This change prevents the header of the hash column from using the monospace font, and keeps all the header with the UI font.

## 2. Related Issue

N/A

## 3. Changes

### Webview (`webview-ui/`)

- webview-ui/src/components/common/Reflog.svelte
- webview-ui/src/components/graph/CommitGraph.svelte

## 4. Type of Change

Check all that apply.

- [ ] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [X] Style / UI update
- [ ] i18n (localization) addition or update
- [ ] Build / configuration change
- [ ] Documentation update
- [ ] Test addition or update

## 5. Testing

Describe how you verified the changes.

- [ ] `npm test` passed
- [ ] `npm run lint` passed
- [X] Manually tested via VS Code Extension Host
- [ ] Verified in both dark and light themes (if UI was changed)

## 6. Screenshots (optional)

Before:

<img width="383" height="207" alt="image" src="https://github.com/user-attachments/assets/c9a67716-430d-4d07-9334-039ce2d120dc" />

After:

<img width="392" height="211" alt="image" src="https://github.com/user-attachments/assets/60854296-9452-439b-92ce-dfb733cfef51" />

## 7. Checklist

- [ ] New message types are defined in `message-bus.ts` (if applicable)
- [ ] UI strings are added to both `en.ts` and `ko.ts` (if applicable)
- [ ] Extension-side strings are added to both `l10n/bundle.l10n.json` and `bundle.l10n.ko.json` (if applicable)
- [ ] No leftover `console.log` or debug code
