### PR TITLE
fix: resolve real gitdir for interactive rebase in submodules

### DIFF
--- a/src/git/__tests__/integration/submodule-lfs-flow.integration.test.ts
+++ b/src/git/__tests__/integration/submodule-lfs-flow.integration.test.ts
@@ -96,6 +96,62 @@ describe('GitService integration — submodule', () => {
     // After update --init, the submodule is checked out again.
     expect(readdirSync(join(parent.path, 'libs', 'lib')).length).toBeGreaterThan(0);
   });
+
+  // Regression: in a submodule `.git` is a file pointing at the real gitdir,
+  // not a directory. Writing the rebase-todo into `<repo>/.git/...` or probing
+  // `<repo>/.git/rebase-merge` failed with ENOTDIR / missed the paused state.
+  describe('interactiveRebase', () => {
+    let subPath: string;
+    let subSvc: GitService;
+
+    beforeEach(() => {
+      subPath = join(parent.path, 'libs', 'lib');
+      subSvc = new GitService(subPath);
+      // The submodule *clone* inherits no identity, and GitService spawns git
+      // with the ambient environment — so a rebase that re-creates commits
+      // would fail with "Committer identity unknown" on a machine without a
+      // global git identity (e.g. CI). Configure it locally like createTempRepo.
+      runGit(subPath, ['config', 'user.name', 'Test User']);
+      runGit(subPath, ['config', 'user.email', 'test@example.com']);
+      runGit(subPath, ['config', 'commit.gpgsign', 'false']);
+    });
+
+    it('reorders commits in a submodule working tree', async () => {
+      const base = runGit(subPath, ['rev-parse', 'HEAD']).trim();
+      const c1 = commit(subPath, 'sub A', { 'a.txt': 'A\n' });
+      const c2 = commit(subPath, 'sub B', { 'b.txt': 'B\n' });
+
+      await subSvc.interactiveRebase(base, [
+        { action: 'pick', hash: c2, subject: 'sub B' },
+        { action: 'pick', hash: c1, subject: 'sub A' },
+      ]);
+
+      const subjects = runGit(subPath, ['log', '--format=%s', `${base}..HEAD`])
+        .trim().split('\n');
+      // git log is reverse-chrono, so newest first.
+      expect(subjects[0]).toBe('sub A');
+      expect(subjects[1]).toBe('sub B');
+    });
+
+    it('detects the paused rebase state when a submodule replay conflicts', async () => {
+      const base = runGit(subPath, ['rev-parse', 'HEAD']).trim();
+      // Two commits touching the same line; reordering them makes git stop with
+      // a conflict, leaving rebase-merge in the submodule's real gitdir.
+      writeFileSync(join(subPath, 'conflict.txt'), '1\n');
+      const c1 = commit(subPath, 'set to 2', { 'conflict.txt': '2\n' });
+      const c2 = commit(subPath, 'set to 3', { 'conflict.txt': '3\n' });
+
+      await expect(subSvc.interactiveRebase(base, [
+        { action: 'pick', hash: c2, subject: 'set to 3' },
+        { action: 'pick', hash: c1, subject: 'set to 2' },
+      ])).resolves.toBeUndefined();
+
+      expect((await subSvc.getOperationState()).type).toBe('rebase');
+
+      await subSvc.abortOperation();
+      expect((await subSvc.getOperationState()).type).toBeNull();
+    });
+  });
 });
 
 // LFS catch-path checks run regardless of whether git-lfs is installed —

--- a/src/git/git-service.ts
+++ b/src/git/git-service.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { randomUUID } from 'crypto';
 import { bufferStream, BufferOverflowError } from '../utils/buffer-stream';
 import { getGitBinaryPath } from './git-binary';
+import { resolveGitDirs } from '../services/file-watcher-helpers';
 
 /** Default max bytes per stdout/stderr stream for a single git invocation.
  *  Picked to comfortably hold large log/diff output (e.g. `git log --all`
@@ -159,6 +160,14 @@ export class GitService {
   }
 
   get rootPath(): string { return this.repoPath; }
+
+  /**
+   * The real gitdir. In a submodule or linked worktree `.git` is a file
+   * pointing at it, so build gitdir paths from here, not by joining `'.git'`.
+   */
+  private gitDir(): string {
+    return resolveGitDirs(this.repoPath).gitDir;
+  }
 
   getActivityLog() {
     return this.activityLog;
@@ -1310,7 +1319,7 @@ export class GitService {
     }
 
     const todoContent = lines.join('\n') + '\n';
-    const todoFile = join(this.repoPath, '.git', `ghg-rebase-todo-${randomUUID()}`);
+    const todoFile = join(this.gitDir(), `ghg-rebase-todo-${randomUUID()}`);
 
     try {
       await writeFile(todoFile, todoContent, 'utf-8');
@@ -1343,7 +1352,7 @@ export class GitService {
           // remains on disk and the UI banner will guide the user to continue / abort.
           // Treat that as a successful "paused" outcome instead of throwing, which
           // would surface a redundant error dialog on top of the banner.
-          const gitDir = join(this.repoPath, '.git');
+          const gitDir = this.gitDir();
           const paused =
             existsSync(join(gitDir, 'rebase-merge')) ||
             existsSync(join(gitDir, 'rebase-apply'));
@@ -1441,7 +1450,7 @@ export class GitService {
     // Don't rely on REBASE_HEAD: git leaves it behind after `rebase --continue`
     // succeeds, which would falsely report a rebase as still in progress. The
     // canonical marker is the rebase state directory.
-    const gitDir = join(this.repoPath, '.git');
+    const gitDir = this.gitDir();
     if (existsSync(join(gitDir, 'rebase-merge')) || existsSync(join(gitDir, 'rebase-apply'))) {
       return { type: 'rebase' };
     }


### PR DESCRIPTION
## Problem

Interactive rebase fails on a submodule with an ENOTDIR ("not a directory")
error. It works fine on a regular repo.

In a submodule — and in a linked worktree — `.git` is a **file** that points
at the real gitdir (`<parent>/.git/modules/<name>` for submodules,
`<main>/.git/worktrees/<name>` for worktrees), not a directory. Three spots in
`GitService` assumed `.git` was always a directory:

- `interactiveRebase()` wrote its rebase-todo to `<repo>/.git/ghg-rebase-todo-*`
  → `writeFile` throws `ENOTDIR`, aborting the rebase.
- `interactiveRebase()`'s paused-state probe checked `<repo>/.git/rebase-merge`
  → never detects the `edit`/conflict pause, so the continue/abort banner
  wouldn't show.
- `getOperationState()` probed `<repo>/.git/{rebase-merge,rebase-apply,SQUASH_MSG}`
  → silently misreports in-progress rebase/squash state in submodules/worktrees.

## Fix

Route all three sites through a new private `gitDir()` helper that reuses the
existing `resolveGitDirs()` utility — the same resolution already used by the
file watcher and `MainPanel`'s conflict probe. This resolves the gitdir
correctly for regular repos, submodules, and linked worktrees alike, keeping
the behavior consistent with the rest of the codebase.

## Tests

Added submodule interactive-rebase integration tests covering both broken code
paths:
- reordering commits in a submodule working tree (the todo-write path), and
- detecting the paused rebase state after a conflicting replay in a submodule.

Both fail on `main` with `ENOTDIR` and pass with the fix. Full backend suite
(710 tests) and `tsc --noEmit` are green.