### PR TITLE
feat: add commands to open worktree paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,16 @@
         "icon": "$(trash)"
       },
       {
+        "command": "gitGraphPlus.openWorktree",
+        "title": "Open Worktree",
+        "icon": "$(go-to-file)"
+      },
+      {
+        "command": "gitGraphPlus.openWorktreeInFileExplorer",
+        "title": "Open in File Explorer",
+        "icon": "$(folder-opened)"
+      },
+      {
         "command": "gitGraphPlus.removeWorktree",
         "title": "%command.removeWorktree%",
         "icon": "$(trash)"
@@ -344,6 +354,16 @@
           "command": "gitGraphPlus.stashDrop",
           "when": "view == gitGraphPlus.stashes && viewItem == stash",
           "group": "2_danger@1"
+        },
+        {
+          "command": "gitGraphPlus.openWorktree",
+          "when": "view == gitGraphPlus.worktrees && (viewItem == worktree || viewItem == worktree-main)",
+          "group": "1_worktree@1"
+        },
+        {
+          "command": "gitGraphPlus.openWorktreeInFileExplorer",
+          "when": "view == gitGraphPlus.worktrees && (viewItem == worktree || viewItem == worktree-main)",
+          "group": "1_worktree@2"
         },
         {
           "command": "gitGraphPlus.removeWorktree",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -311,6 +311,23 @@ export function activate(context: vscode.ExtensionContext) {
   MainPanel.onSidebarRefresh = refreshAll;
   MainPanel.onRepoChange = switchToRepo;
 
+  function getWorktreeUri(wtItem: { worktree?: { path?: string } } | undefined): vscode.Uri | undefined {
+    const wtPath = wtItem?.worktree?.path;
+    return wtPath ? vscode.Uri.file(wtPath) : undefined;
+  }
+
+  function openWorktree(wtItem: { worktree?: { path?: string } } | undefined): void {
+    const uri = getWorktreeUri(wtItem);
+    if (!uri) { return; }
+    vscode.commands.executeCommand('vscode.openFolder', uri, { forceNewWindow: true });
+  }
+
+  function openWorktreeInFileExplorer(wtItem: { worktree?: { path?: string } } | undefined): void {
+    const uri = getWorktreeUri(wtItem);
+    if (!uri) { return; }
+    vscode.env.openExternal(uri);
+  }
+
   // Auto-switch sidebar when the active editor moves to a different repo
   if (builtinGit) {
     const waitForGitApi = builtinGit.isActive
@@ -554,6 +571,8 @@ export function activate(context: vscode.ExtensionContext) {
         MainPanel.showModalWithPanel(context.extensionUri, { modal: 'deleteRemoteBranch', remote, name: branchName });
       }
     }),
+    vscode.commands.registerCommand('gitGraphPlus.openWorktree', openWorktree),
+    vscode.commands.registerCommand('gitGraphPlus.openWorktreeInFileExplorer', openWorktreeInFileExplorer),
     vscode.commands.registerCommand('gitGraphPlus.removeWorktree', (wtItem) => {
       if (wtItem?.worktree) {
         const wtPath = wtItem.worktree.path;

--- a/src/views/worktrees-view.ts
+++ b/src/views/worktrees-view.ts
@@ -68,6 +68,11 @@ class WorktreeItem extends vscode.TreeItem {
       displayPath = worktree.path;
     }
     this.description = worktree.isMain ? '' : displayPath;
+    this.command = {
+      command: 'gitGraphPlus.openWorktree',
+      title: 'Open Worktree',
+      arguments: [this],
+    };
     this.tooltip = [
       `Path: ${worktree.path}`,
       `Branch: ${worktree.branch || '(detached)'}`,


### PR DESCRIPTION
# Pull Request

## 1. Summary

Add worktree context menu actions to open a worktree in a new VS Code window or reveal it in the file explorer. Also make worktree tree items open the worktree directly when selected.

## 2. Related Issue

- Closes #35

## 3. Changes

### Extension (`src/`)

- extension.ts
- views/worktrees-view.ts

### Other (build, config, docs, etc.)

- package.json

## 4. Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [ ] Style / UI update
- [ ] i18n (localization) addition or update
- [ ] Build / configuration change
- [ ] Documentation update
- [ ] Test addition or update

## 5. Testing

- [ ] `npm test` passed
- [ ] `npm run lint` passed
- [x] Manually tested via VS Code Extension Host
- [ ] Verified in both dark and light themes (if UI was changed)

## 6. Screenshots (optional)

NA

## 7. Checklist

- [ ] New message types are defined in `message-bus.ts` (if applicable)
- [ ] UI strings are added to both `en.ts` and `ko.ts` (if applicable)
- [ ] Extension-side strings are added to both `l10n/bundle.l10n.json` and `bundle.l10n.ko.json` (if applicable)
- [x] No leftover `console.log` or debug code