### PR TITLE
feat: support existing branches when adding worktrees

### DIFF
--- a/src/__tests__/extension.test.ts
+++ b/src/__tests__/extension.test.ts
@@ -6,9 +6,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // resolver. Everything it imports is stubbed so activate() runs to completion.
 const H = vi.hoisted(() => ({
   registeredCommands: [] as string[],
+  commandHandlers: {} as Record<string, (...args: unknown[]) => unknown>,
   treeViewsCreated: [] as string[],
   workspaceFolders: undefined as Array<{ uri: { fsPath: string } }> | undefined,
   gitPathConfig: null as string | string[] | null,
+  worktreeList: [] as Array<{ path: string; isMain: boolean }>,
 }));
 
 vi.mock('vscode', () => ({
@@ -35,7 +37,7 @@ vi.mock('vscode', () => ({
     activeTextEditor: undefined,
   },
   commands: {
-    registerCommand: (id: string) => { H.registeredCommands.push(id); return { dispose() {} }; },
+    registerCommand: (id: string, cb: (...args: unknown[]) => unknown) => { H.registeredCommands.push(id); H.commandHandlers[id] = cb; return { dispose() {} }; },
     executeCommand: vi.fn(),
   },
   extensions: { getExtension: () => undefined },
@@ -57,7 +59,7 @@ vi.mock('../panels/MainPanel', () => ({
   },
 }));
 vi.mock('../services/git-content-provider', () => ({ GitContentProvider: class {} }));
-vi.mock('../git/git-service', () => ({ GitService: class { setExtraEnv() {} get rootPath() { return '/repo'; } } }));
+vi.mock('../git/git-service', () => ({ GitService: class { setExtraEnv() {} get rootPath() { return '/repo'; } worktreeList() { return Promise.resolve(H.worktreeList); } } }));
 vi.mock('../services/file-watcher', () => ({ FileWatcher: class { enabled = true; suppress() {} dispose() {} } }));
 const viewStub = () => ({ ViewProvider: undefined });
 vi.mock('../views/branches-view', () => ({ BranchesViewProvider: class { refresh() {} dispose() {} setGitService() {} prefetch() { return Promise.resolve(); } getCurrentItem() { return null; } } }));
@@ -78,9 +80,11 @@ function makeContext() {
 
 beforeEach(() => {
   H.registeredCommands = [];
+  H.commandHandlers = {};
   H.treeViewsCreated = [];
   H.workspaceFolders = undefined;
   H.gitPathConfig = null;
+  H.worktreeList = [];
   vi.mocked(existsSync).mockReturnValue(true);
 });
 
@@ -136,5 +140,23 @@ describe('activate', () => {
       'gitGraphPlus.stashes',
       'gitGraphPlus.worktrees',
     ]);
+  });
+
+  it('addWorktree defaults beside the main worktree even when active repo is linked worktree', async () => {
+    H.workspaceFolders = [{ uri: { fsPath: '/repos/project.worktrees/custom.worktrees' } }];
+    H.worktreeList = [
+      { path: '/repos/project', isMain: true },
+      { path: '/repos/project.worktrees/custom.worktrees', isMain: false },
+    ];
+    const ctx = makeContext();
+    activate(ctx);
+
+    await H.commandHandlers['gitGraphPlus.addWorktree']();
+
+    const { MainPanel } = await import('../panels/MainPanel');
+    expect(MainPanel.showModalWithPanel).toHaveBeenCalledWith(ctx.extensionUri, {
+      modal: 'addWorktree',
+      defaultPath: '/repos/project.worktrees',
+    });
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -476,8 +476,17 @@ export function activate(context: vscode.ExtensionContext) {
       const index = stashItem?.index ?? 0;
       MainPanel.showModalWithPanel(context.extensionUri, { modal: 'stashDrop', index, message: stashItem?.stash?.message ?? `stash@{${index}}` });
     }),
-    vscode.commands.registerCommand('gitGraphPlus.addWorktree', () => {
-      const defaultPath = path.join(path.dirname(activeRepoPath), `${path.basename(activeRepoPath)}-worktree`);
+    vscode.commands.registerCommand('gitGraphPlus.addWorktree', async () => {
+      let baseRepoPath = activeRepoPath;
+      try {
+        const mainWorktree = (await activeGitService.worktreeList()).find(w => w.isMain);
+        if (mainWorktree?.path) {
+          baseRepoPath = mainWorktree.path;
+        }
+      } catch (err) {
+        console.warn('Git Graph+: failed to resolve main worktree path:', err instanceof Error ? err.message : err);
+      }
+      const defaultPath = path.join(path.dirname(baseRepoPath), `${path.basename(baseRepoPath)}.worktrees`);
       MainPanel.showModalWithPanel(context.extensionUri, { modal: 'addWorktree', defaultPath });
     }),
     vscode.commands.registerCommand('gitGraphPlus.pruneWorktrees', () => {

--- a/webview-ui/src/components/modals/AddWorktreeModal.svelte
+++ b/webview-ui/src/components/modals/AddWorktreeModal.svelte
@@ -12,54 +12,115 @@
     onAdd: (path: string, branch?: string, newBranch?: string) => void;
   }
 
+  type WorktreeMode = 'existing' | 'new';
+
   let { defaultPath = '', onClose, onAdd }: Props = $props();
 
   const localBranches = $derived(branchStore.localBranches.map(b => b.name));
+  const checkedOutBranches = $derived(new Set(branchStore.worktrees.map(w => w.branch).filter(Boolean)));
+  const availableExistingBranches = $derived(localBranches.filter(b => !checkedOutBranches.has(b)));
+  const startAtOptions = $derived(localBranches.length > 0 ? localBranches : ['HEAD']);
+  let existingBranch = $state('');
   // svelte-ignore state_referenced_locally
   let startAt = $state(branchStore.currentBranch?.name ?? 'HEAD');
+  let mode = $state<WorktreeMode>('existing');
   let branchName = $state('');
   // svelte-ignore state_referenced_locally
   let location = $state(defaultPath);
   let branchInput: HTMLInputElement | undefined = $state();
 
+  const sourceRef = $derived(startAt || 'HEAD');
+  const folderName = $derived(mode === 'new' ? branchName.trim() : existingBranch);
+
+  function worktreeFolder(basePath: string, name: string): string {
+    const sanitized = name.replace(/[\\/]+/g, '-');
+    if (!basePath) return sanitized;
+    return basePath.replace(/[\\/]+$/, '') + '/' + sanitized;
+  }
+
   $effect(() => {
-    if (defaultPath && branchName) {
-      location = defaultPath + branchName.replace(/\//g, '-');
+    if (!startAtOptions.includes(startAt)) {
+      startAt = startAtOptions[0] ?? 'HEAD';
+    }
+    if (!existingBranch || !availableExistingBranches.includes(existingBranch)) {
+      existingBranch = availableExistingBranches[0] ?? '';
+    }
+    if (mode === 'existing' && availableExistingBranches.length === 0) {
+      mode = 'new';
+    }
+  });
+
+  $effect(() => {
+    if (defaultPath && folderName) {
+      location = worktreeFolder(defaultPath, folderName);
     } else if (defaultPath) {
       location = defaultPath;
     }
   });
 
-  onMount(() => { branchInput?.focus(); });
+  onMount(() => { if (mode === 'new') branchInput?.focus(); });
 
-  const refError = $derived(branchName.trim() !== '' ? validateGitRefName(branchName.trim()) : null);
-  const canSubmit = $derived(branchName.trim() !== '' && location.trim() !== '' && !refError);
-
+  const refError = $derived(mode === 'new' && branchName.trim() !== '' ? validateGitRefName(branchName.trim()) : null);
+  const canSubmit = $derived(
+    location.trim() !== ''
+      && (mode === 'new'
+        ? branchName.trim() !== '' && !refError
+        : existingBranch !== '')
+  );
   function handleSubmit() {
     if (!canSubmit) return;
-    onAdd(location.trim(), startAt, branchName.trim());
+    if (mode === 'new') {
+      onAdd(location.trim(), sourceRef, branchName.trim());
+    } else {
+      onAdd(location.trim(), existingBranch);
+    }
   }
 </script>
 
 <Modal title={t('worktree.addTitle')} {onClose}>
-  <div class="modal-form-group">
-    <div class="modal-field-row">
-      <div class="modal-field-label">{t('worktree.startAt')}</div>
-      <ColorSelect
-        options={localBranches.map(b => ({ value: b, label: b, color: '' }))}
-        value={startAt}
-        onChange={(v) => { startAt = v; }}
-        showDot={false}
-      />
-    </div>
+  <div class="modal-form-group mode-options" role="radiogroup" aria-label={t('worktree.mode')}>
+    <label class="modal-radio">
+      <input type="radio" name="worktree-mode" value="existing" bind:group={mode} disabled={availableExistingBranches.length === 0} />
+      <span>{t('worktree.useExisting')}</span>
+    </label>
+    <label class="modal-radio">
+      <input type="radio" name="worktree-mode" value="new" bind:group={mode} />
+      <span>{t('worktree.createNewBranch')}</span>
+    </label>
   </div>
 
-  <div class="modal-form-group">
-    <div class="modal-field-row">
-      <label class="modal-field-label" for="wt-branch">{t('worktree.branchName')}</label>
-      <input id="wt-branch" class="modal-input" type="text" bind:value={branchName} bind:this={branchInput} placeholder={t('worktree.branchPlaceholder')} onkeydown={(e) => { if (e.key === 'Enter' && canSubmit) handleSubmit(); }} />
+  {#if mode === 'existing'}
+    <div class="modal-form-group">
+      <div class="modal-field-row">
+        <div class="modal-field-label">{t('worktree.existingBranch')}</div>
+        <ColorSelect
+          options={availableExistingBranches.map(b => ({ value: b, label: b, color: '' }))}
+          value={existingBranch}
+          onChange={(v) => { existingBranch = v; }}
+          showDot={false}
+        />
+      </div>
     </div>
-  </div>
+  {:else}
+    <div class="modal-form-group">
+      <div class="modal-field-row">
+        <div class="modal-field-label">{t('worktree.startAt')}</div>
+        <ColorSelect
+          options={startAtOptions.map(b => ({ value: b, label: b, color: '' }))}
+          value={startAt}
+          onChange={(v) => { startAt = v; }}
+          showDot={false}
+        />
+      </div>
+    </div>
+
+    <div class="modal-form-group">
+      <div class="modal-field-row">
+        <label class="modal-field-label" for="wt-branch">{t('worktree.branchName')}</label>
+        <input id="wt-branch" class="modal-input" type="text" bind:value={branchName} bind:this={branchInput} placeholder={t('worktree.branchPlaceholder')} onkeydown={(e) => { if (e.key === 'Enter' && canSubmit) handleSubmit(); }} />
+      </div>
+    </div>
+  {/if}
 
   <div class="modal-form-group">
     <div class="modal-field-row">
@@ -82,5 +143,11 @@
     font-family: var(--vscode-editor-font-family, monospace);
     font-size: 11px;
     color: var(--text-secondary);
+  }
+
+  .mode-options {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
   }
 </style>

--- a/webview-ui/src/components/modals/__tests__/AddWorktreeModal.test.ts
+++ b/webview-ui/src/components/modals/__tests__/AddWorktreeModal.test.ts
@@ -4,10 +4,10 @@ import { tick } from 'svelte';
 import AddWorktreeModal from '../AddWorktreeModal.svelte';
 import { branchStore } from '../../../lib/stores/branches.svelte';
 import { i18n } from '../../../lib/i18n/index.svelte';
-import type { BranchInfo } from '../../../lib/types';
+import type { BranchInfo, WorktreeInfo } from '../../../lib/types';
 
-function setBranches(branches: BranchInfo[]) {
-  branchStore.setData({ branches, tags: [], remotes: [], stashes: [], worktrees: [] });
+function setBranches(branches: BranchInfo[], worktrees: WorktreeInfo[] = []) {
+  branchStore.setData({ branches, tags: [], remotes: [], stashes: [], worktrees });
 }
 
 beforeEach(() => {
@@ -25,6 +25,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd: vi.fn(),
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const submit = container.querySelector<HTMLButtonElement>('button.primary')!;
     expect(submit.disabled).toBe(true);
 
@@ -36,17 +39,36 @@ describe('AddWorktreeModal', () => {
     expect(submit.disabled).toBe(false);
   });
 
-  it('auto-fills location = defaultPath + branchName (slashes replaced with dashes)', async () => {
+  it('auto-fills location as a child folder under defaultPath (slashes replaced with dashes)', async () => {
     const { container } = render(AddWorktreeModal, {
       defaultPath: '/Users/me/worktrees/',
       onClose: vi.fn(),
       onAdd: vi.fn(),
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     const locationInput = container.querySelector<HTMLInputElement>('#wt-location')!;
     await fireEvent.input(branchInput, { target: { value: 'feature/login' } });
     await tick();
     expect(locationInput.value).toBe('/Users/me/worktrees/feature-login');
+  });
+
+  it('inserts a path separator when defaultPath has no trailing slash', async () => {
+    const { container } = render(AddWorktreeModal, {
+      defaultPath: '/Users/me/project.worktrees',
+      onClose: vi.fn(),
+      onAdd: vi.fn(),
+    });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
+    const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
+    const locationInput = container.querySelector<HTMLInputElement>('#wt-location')!;
+    await fireEvent.input(branchInput, { target: { value: 'test' } });
+    await tick();
+    expect(locationInput.value).toBe('/Users/me/project.worktrees/test');
   });
 
   it('keeps location at defaultPath when branch name is cleared', async () => {
@@ -55,6 +77,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd: vi.fn(),
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     const locationInput = container.querySelector<HTMLInputElement>('#wt-location')!;
     await fireEvent.input(branchInput, { target: { value: 'feat' } });
@@ -72,6 +97,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd: vi.fn(),
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     const locationInput = container.querySelector<HTMLInputElement>('#wt-location')!;
     await fireEvent.input(locationInput, { target: { value: '/my/custom/path' } });
@@ -88,6 +116,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd,
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     await fireEvent.input(branchInput, { target: { value: 'feat' } });
     await tick();
@@ -102,6 +133,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd,
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     // Open the startAt ColorSelect and pick "develop"
     await fireEvent.click(container.querySelector<HTMLButtonElement>('.color-select-btn')!);
     const opts = container.querySelectorAll<HTMLButtonElement>('.color-select-option');
@@ -120,6 +154,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd: vi.fn(),
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const submit = container.querySelector<HTMLButtonElement>('button.primary')!;
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     // Leading dash would otherwise reach git as an option-style positional arg.
@@ -145,6 +182,9 @@ describe('AddWorktreeModal', () => {
       onClose: vi.fn(),
       onAdd,
     });
+    const newBranchRadio = container.querySelector<HTMLInputElement>('input[type="radio"][value="new"]')!;
+    await fireEvent.click(newBranchRadio);
+    await tick();
     const branchInput = container.querySelector<HTMLInputElement>('#wt-branch')!;
     const locationInput = container.querySelector<HTMLInputElement>('#wt-location')!;
     await fireEvent.input(branchInput, { target: { value: '  feature/x  ' } });
@@ -154,5 +194,56 @@ describe('AddWorktreeModal', () => {
 
     // startAt defaults to currentBranch.name = 'main'.
     expect(onAdd).toHaveBeenCalledWith('/tmp/wt', 'main', 'feature/x');
+  });
+
+  it('defaults to the first existing branch not already checked out in a worktree', async () => {
+    const onAdd = vi.fn();
+    setBranches([
+      { name: 'main', current: true, hash: 'abc', ahead: 0, behind: 0 },
+      { name: 'develop', current: false, hash: 'def', ahead: 0, behind: 0 },
+    ], [
+      { path: '/repo', hash: 'abc', branch: 'main', detached: false, locked: false, prunable: false, isMain: true },
+    ]);
+
+    const { container } = render(AddWorktreeModal, {
+      defaultPath: '/wt/',
+      onClose: vi.fn(),
+      onAdd,
+    });
+    await tick();
+    await tick();
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('button.primary')!);
+
+    expect(onAdd).toHaveBeenCalledWith('/wt/develop', 'develop');
+  });
+
+  it('filters branches that are already checked out in worktrees from existing branch mode', async () => {
+    const onAdd = vi.fn();
+    setBranches([
+      { name: 'main', current: true, hash: 'abc', ahead: 0, behind: 0 },
+      { name: 'develop', current: false, hash: 'def', ahead: 0, behind: 0 },
+      { name: 'feature/free', current: false, hash: 'fed', ahead: 0, behind: 0 },
+    ], [
+      { path: '/repo', hash: 'abc', branch: 'main', detached: false, locked: false, prunable: false, isMain: true },
+      { path: '/repo-wt-develop', hash: 'def', branch: 'develop', detached: false, locked: false, prunable: false, isMain: false },
+    ]);
+
+    const { container } = render(AddWorktreeModal, {
+      defaultPath: '/wt/',
+      onClose: vi.fn(),
+      onAdd,
+    });
+    await tick();
+    await tick();
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('.color-select-btn')!);
+    const options = Array.from(container.querySelectorAll<HTMLButtonElement>('.color-select-option'))
+      .map(o => o.textContent ?? '');
+    expect(options.some(text => text.includes('main'))).toBe(false);
+    expect(options.some(text => text.includes('develop'))).toBe(false);
+    expect(options.some(text => text.includes('feature/free'))).toBe(true);
+
+    await fireEvent.click(container.querySelector<HTMLButtonElement>('button.primary')!);
+    expect(onAdd).toHaveBeenCalledWith('/wt/feature-free', 'feature/free');
   });
 });

--- a/webview-ui/src/lib/i18n/en.ts
+++ b/webview-ui/src/lib/i18n/en.ts
@@ -468,7 +468,11 @@ export const en: Record<string, string> = {
 
   // Worktree modals
   'worktree.addTitle': 'Add Worktree',
+  'worktree.mode': 'Worktree mode',
   'worktree.startAt': 'Start at:',
+  'worktree.useExisting': 'Use existing branch',
+  'worktree.existingBranch': 'Branch:',
+  'worktree.createNewBranch': 'Create a new branch',
   'worktree.branchName': 'Branch name:',
   'worktree.branchPlaceholder': 'Enter Branch Name',
   'worktree.location': 'Location:',

--- a/webview-ui/src/lib/i18n/ko.ts
+++ b/webview-ui/src/lib/i18n/ko.ts
@@ -468,7 +468,11 @@ export const ko: Record<string, string> = {
 
   // Worktree modals
   'worktree.addTitle': 'Worktree 추가',
+  'worktree.mode': 'Worktree 모드',
   'worktree.startAt': '시작점:',
+  'worktree.useExisting': '기존 브랜치 사용',
+  'worktree.existingBranch': '브랜치:',
+  'worktree.createNewBranch': '새 브랜치 만들기',
   'worktree.branchName': '브랜치 이름:',
   'worktree.branchPlaceholder': '브랜치 이름 입력',
   'worktree.location': '위치:',

--- a/webview-ui/src/lib/i18n/zh.ts
+++ b/webview-ui/src/lib/i18n/zh.ts
@@ -468,7 +468,11 @@ export const zh: Record<string, string> = {
 
   // Worktree modals
   'worktree.addTitle': '添加工作树',
+  'worktree.mode': '工作树模式',
   'worktree.startAt': '基于：',
+  'worktree.useExisting': '使用现有分支',
+  'worktree.existingBranch': '分支：',
+  'worktree.createNewBranch': '创建新分支',
   'worktree.branchName': '分支名：',
   'worktree.branchPlaceholder': '输入分支名',
   'worktree.location': '位置：',


### PR DESCRIPTION
# Pull Request

## 1. Summary

Support creating worktrees from existing branches in addition to creating a new branch. The add-worktree modal now separates existing-branch and new-branch flows, filters out branches already checked out in worktrees, and uses cleaner default worktree paths based on the main worktree.

## 2. Related Issue

- NA

## 3. Changes

### Extension (`src/`)

- `src/extension.ts`
  - Resolve the main worktree path before building the default add-worktree folder.
  - Default new worktrees under `<main-repo>.worktrees`.
- `src/__tests__/extension.test.ts`
  - Add coverage for add-worktree default path resolution when the active repo is a linked worktree.

### Webview (`webview-ui/`)

- `webview-ui/src/components/modals/AddWorktreeModal.svelte`
  - Add separate modes for using an existing branch and creating a new branch.
  - Show only the existing branch selector in existing-branch mode.
  - Show `Start at` and branch name fields only in new-branch mode.
  - Filter out branches already checked out in worktrees.
  - Generate default worktree folders as child paths under the default base folder.
- `webview-ui/src/components/modals/__tests__/AddWorktreeModal.test.ts`
  - Update modal tests for the new mode selection behavior.
  - Add coverage for branch filtering and default folder path generation.
- `webview-ui/src/lib/i18n/en.ts`
- `webview-ui/src/lib/i18n/ko.ts`
- `webview-ui/src/lib/i18n/zh.ts`
  - Add localized strings for the new add-worktree mode labels.

### Other (build, config, docs, etc.)

- N/A

## 4. Type of Change

Check all that apply.

- [x] New feature
- [ ] Bug fix
- [ ] Refactoring (no functional changes)
- [x] Style / UI update
- [x] i18n (localization) addition or update
- [ ] Build / configuration change
- [ ] Documentation update
- [x] Test addition or update

## 5. Testing

Describe how you verified the changes.

- [x] `npm test` passed
- [x] `npm run lint` passed
- [x] Manually tested via VS Code Extension Host
- [ ] Verified in both dark and light themes (if UI was changed)

## 6. Screenshots (optional)


### Before change

![before](https://github.com/user-attachments/assets/cc9263ca-a9a7-43c9-ba80-aac9eac8969c)

### After change

![after, existing branch](https://github.com/user-attachments/assets/9ddb6cdd-f8e7-44d2-8c9d-413662c3bfd2)

![after, new branch](https://github.com/user-attachments/assets/481646c1-f9f7-4358-8aa8-a65148a5cd33)

## 7. Checklist

- [ ] New message types are defined in `message-bus.ts` (if applicable)
- [x] UI strings are added to both `en.ts` and `ko.ts` (if applicable)
- [ ] Extension-side strings are added to both `l10n/bundle.l10n.json` and `bundle.l10n.ko.json` (if applicable)
- [x] No leftover `console.log` or debug code

## 8. Additional Context (optional)

The existing-branch option intentionally excludes branches already checked out in worktrees because Git does not allow the same branch to be checked out in multiple worktrees.
