### PR TITLE
fix: keep the search bar visible during a conflict

### DIFF
--- a/webview-ui/src/App.svelte
+++ b/webview-ui/src/App.svelte
@@ -460,7 +460,7 @@ import AmendModal from './components/modals/AmendModal.svelte';
 
   <div class="content-area">
     {#if uiStore.viewMode === 'graph'}
-      {#if !bisectMessage && !conflict && !rebasePaused}
+      {#if !bisectMessage}
         <SearchBar
           onResults={handleSearchResults}
           onNavigate={handleSearchNavigate}

--- a/webview-ui/src/__tests__/App.test.ts
+++ b/webview-ui/src/__tests__/App.test.ts
@@ -160,6 +160,19 @@ describe('App — message handling', () => {
     });
   });
 
+  it('conflict keeps the search bar visible (issue #69)', async () => {
+    const { container } = render(App);
+    await waitFor(() => expect(container.querySelector('.search-input')).not.toBeNull());
+    postMsg('conflictData', {
+      operation: 'rebase',
+      files: [{ path: 'a.ts', resolved: false }],
+    });
+    await waitFor(() => {
+      expect(container.querySelector('.conflict-banner')).not.toBeNull();
+      expect(container.querySelector('.search-input')).not.toBeNull();
+    });
+  });
+
   it('operationPaused with rebase shows the rebase pause banner', async () => {
     const { container } = render(App);
     postMsg('operationPaused', { operation: 'rebase' });


### PR DESCRIPTION
The search bar (and Jump to HEAD) was hidden whenever a conflict or paused rebase was active, because the SearchBar rendered only when `!conflict && !rebasePaused`. The conflict banner is a separate top-level banner, so nothing needs to take the search slot — only bisect still replaces it with its own banner.\n\nFixes #69.